### PR TITLE
added variables default to scss version

### DIFF
--- a/src/typebase.scss
+++ b/src/typebase.scss
@@ -1,18 +1,22 @@
 /*! Typebase.less v0.1.0 | MIT License */
 
 // Typesetting variables. Edit these!
-$baseFontSize:22; // in pixels. This would result in 22px on desktop
-$baseLineHeight:1.5; // how large the line height is as a multiple of font size
+$baseFontSize:22!default; // in pixels. This would result in 22px on desktop
+$baseLineHeight:1.5!default; // how large the line height is as a multiple of font size
 $leading:$baseLineHeight * 1rem;
 // Rate of growth for headings
 // I actually like this to be slightly smaller then the leading. Makes for tight headings.
-$scale:1.414;
+$scale:1.414!default;
+
+//font family
+$font-family-default: serif !default;
+$font-family-headings: sans-serif !default;
 
 /* Setup */
 
 html {
     /* Change default typefaces here */
-    font-family: serif;
+    font-family: $font-family-default;
     font-size: $baseFontSize / 16 * 100%;
     // Make everything look a little nicer in webkit
     -webkit-font-smoothing: antialiased;
@@ -57,7 +61,7 @@ h4,
 h5,
 h6 {
     /* Change heading typefaces here */
-    font-family: sans-serif;
+    font-family: $font-family-headings;
     margin-top: $leading;
     margin-bottom: 0;
     line-height: $leading;


### PR DESCRIPTION
added !default (http://sass-lang.com/documentation/file.SASS_REFERENCE.html#variable_defaults_) to scss version, so the settings can be overridden without editing typebase.scss file.
