### PR TITLE
Update deprecated slash as division operation

### DIFF
--- a/src/typebase.sass
+++ b/src/typebase.sass
@@ -1,5 +1,8 @@
 /*! Typebase.less v0.1.0 | MIT License */
 
+// Import of the math.div function for slash as division change
+@use "sass:math"
+
 // Typesetting variables. Edit here or override in main file prior to import of this.
 $baseFontSize: 22  !default // in pixels. This would result in 22px on desktop
 $baseLineHeight: 1.5  !default // how large the line height is as a multiple of font size
@@ -13,7 +16,7 @@ $scale: 1.414  !default
 html
   /* Change default typefaces here */
   font-family: serif
-  font-size: $baseFontSize / 16 * 100%
+  font-size: math.div($baseFontSize, 16) * 100%
 
   // Make everything look a little nicer in webkit
   -webkit-font-smoothing: antialiased
@@ -63,11 +66,11 @@ h2
 h3
   font-size: 1 * $scale * 1rem
 h4
-  font-size: $scale / 2 * 1rem
+  font-size: math.div($scale, 2) * 1rem
 h5
-  font-size: $scale / 3 * 1rem
+  font-size: math.div($scale, 3) * 1rem
 h6
-  font-size: $scale / 4 * 1rem
+  font-size: math.div($scale, 4) * 1rem
 
 /* Tables */
 table

--- a/src/typebase.scss
+++ b/src/typebase.scss
@@ -1,5 +1,8 @@
 /*! Typebase.scss v0.1.0 | MIT License */
 
+// Import of the math.div function for slash as division change
+@use "sass:math";
+
 // Typesetting variables. Edit here or override in main file prior to import of this.
 $baseFontSize:22 !default; // in pixels. This would result in 22px on desktop
 $baseLineHeight:1.5 !default; // how large the line height is as a multiple of font size
@@ -13,7 +16,7 @@ $scale:1.414 !default;
 html {
     /* Change default typefaces here */
     font-family: serif;
-    font-size: $baseFontSize / 16 * 100%;
+    font-size: math.div($baseFontSize, 16) * 100%;
     // Make everything look a little nicer in webkit
     -webkit-font-smoothing: antialiased;
     // -webkit-text-size-adjust: auto
@@ -76,13 +79,13 @@ h3 {
     font-size: 1 * $scale * 1rem;
 }
 h4 {
-    font-size: $scale / 2 * 1rem;
+    font-size: math.div($scale, 2) * 1rem;
 }
 h5 {
-    font-size: $scale / 3 * 1rem;
+    font-size: math.div($scale, 3) * 1rem;
 }
 h6 {
-    font-size: $scale / 4 * 1rem;
+    font-size: math.div($scale, 4) * 1rem;
 }
 /* Tables */
 


### PR DESCRIPTION
I found this deprecation in the SASS and SCSS files when building the sources. This will soon be deprecated because the `/` symbol is being used as division and separator, and the actual usage of this element is confusing, so they introduced the function `math.div(X, Y)`.

The message given during the build is:
```
DEPRECATION WARNING: Using / for division is deprecated and will be removed in Dart Sass 2.0.0.

Recommendation: math.div($scale, 2)

More info and automated migrator: https://sass-lang.com/d/slash-div
```

I implemented the suggested change as shown here [https://sass-lang.com/d/slash-div](https://sass-lang.com/d/slash-div), and fixed the compilation warnings in both the SASS and SCSS sources by using the `@use "sass:math";` import and then the `math.div(X, Y)` function where necessary.

